### PR TITLE
fix: set version keyword config on injected plugin

### DIFF
--- a/git-versioner-maven-core/src/main/java/com/github/manikmagar/maven/versioner/core/git/JGit.java
+++ b/git-versioner-maven-core/src/main/java/com/github/manikmagar/maven/versioner/core/git/JGit.java
@@ -5,6 +5,8 @@ import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 
+import java.io.File;
+
 public class JGit {
 
 	private JGit() {
@@ -15,6 +17,20 @@ public class JGit {
 			try (Git git = new Git(repository)) {
 				return work.apply(git);
 			}
+		} catch (Exception e) {
+			throw new GitVersionerException(e.getMessage(), e);
+		}
+	}
+
+	/**
+	 * Find local git dir by scanning upwards to find .git dir
+	 * 
+	 * @return
+	 */
+	public static String findGitDir(String basePath) {
+		try (Repository repository = new FileRepositoryBuilder().readEnvironment().findGitDir(new File(basePath))
+				.build()) {
+			return repository.getDirectory().getAbsolutePath();
 		} catch (Exception e) {
 			throw new GitVersionerException(e.getMessage(), e);
 		}

--- a/git-versioner-maven-plugin/src/main/java/com/github/manikmagar/maven/versioner/plugin/mojo/VersionCommit.java
+++ b/git-versioner-maven-plugin/src/main/java/com/github/manikmagar/maven/versioner/plugin/mojo/VersionCommit.java
@@ -1,5 +1,6 @@
 package com.github.manikmagar.maven.versioner.plugin.mojo;
 
+import com.github.manikmagar.maven.versioner.core.git.JGit;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -55,7 +56,7 @@ public abstract class VersionCommit extends AbstractVersionerMojo {
 		try {
 			// Use local git configuration for any write operations to retain local user
 			// settings such as sign
-			String gitDir = mavenProject.getBasedir().getAbsoluteFile().toPath().resolve(".git").toString();
+			String gitDir = JGit.findGitDir(mavenProject.getBasedir().getAbsoluteFile().toPath().toString());
 			boolean completed = new ProcessBuilder()
 					.command("git", "--git-dir", gitDir, "commit", "--allow-empty", "-m", resolvedMessage).inheritIO()
 					.start().waitFor(5, TimeUnit.SECONDS);


### PR DESCRIPTION
When [overriding the version keywords](https://github.com/manikmagar/git-versioner-maven-extension#versionKeywords_custom), the injected plugin was missing this configuration. This caused version commit goals to use default version keywords (major, minor, patch) instead of the ones overridden in the extension properties file.