### PR TITLE
Ensure that jGit finds the .git directory

### DIFF
--- a/git-versioner-maven-core/src/main/java/com/github/manikmagar/maven/versioner/core/git/GitTag.java
+++ b/git-versioner-maven-core/src/main/java/com/github/manikmagar/maven/versioner/core/git/GitTag.java
@@ -2,20 +2,22 @@ package com.github.manikmagar.maven.versioner.core.git;
 
 import org.eclipse.jgit.lib.Ref;
 
+import java.io.File;
+
 public class GitTag {
 
 	private GitTag() {
 
 	}
 
-	public static String create(final String tagName, final String tagMessage) {
-		return JGit.executeOperation(git -> {
+	public static String create(File basePath, final String tagName, final String tagMessage) {
+		return JGit.executeOperation(basePath, git -> {
 			Ref tag = git.tag().setName(tagName).setMessage(tagMessage).call();
 			return String.format("%s@%s", tag.getName(), tag.getObjectId().getName());
 		});
 	}
 
-	public static boolean exists(final String tagName) {
-		return JGit.executeOperation(git -> null != git.getRepository().findRef("refs/tags/" + tagName));
+	public static boolean exists(File basePath, final String tagName) {
+		return JGit.executeOperation(basePath, git -> null != git.getRepository().findRef("refs/tags/" + tagName));
 	}
 }

--- a/git-versioner-maven-core/src/main/java/com/github/manikmagar/maven/versioner/core/git/JGit.java
+++ b/git-versioner-maven-core/src/main/java/com/github/manikmagar/maven/versioner/core/git/JGit.java
@@ -12,8 +12,8 @@ public class JGit {
 	private JGit() {
 	}
 
-	public static <R> R executeOperation(Operation<Git, R> work) throws GitVersionerException {
-		try (Repository repository = new FileRepositoryBuilder().readEnvironment().findGitDir().build()) {
+	public static <R> R executeOperation(File basePath, Operation<Git, R> work) throws GitVersionerException {
+		try (Repository repository = new FileRepositoryBuilder().readEnvironment().findGitDir(basePath).build()) {
 			try (Git git = new Git(repository)) {
 				return work.apply(git);
 			}
@@ -24,8 +24,6 @@ public class JGit {
 
 	/**
 	 * Find local git dir by scanning upwards to find .git dir
-	 * 
-	 * @return
 	 */
 	public static String findGitDir(String basePath) {
 		try (Repository repository = new FileRepositoryBuilder().readEnvironment().findGitDir(new File(basePath))

--- a/git-versioner-maven-core/src/main/java/com/github/manikmagar/maven/versioner/core/git/JGitVersioner.java
+++ b/git-versioner-maven-core/src/main/java/com/github/manikmagar/maven/versioner/core/git/JGitVersioner.java
@@ -42,7 +42,7 @@ public class JGitVersioner implements Versioner {
 					versionStrategy.increment(VersionComponentType.MAJOR, hash);
 				} else if (hasValue(commit.getFullMessage(), versionConfig.getKeywords().getMinorKey())) {
 					versionStrategy.increment(VersionComponentType.MINOR, hash);
-				} else if (hasValue(commit.getFullMessage(),versionConfig.getKeywords().getPatchKey())) {
+				} else if (hasValue(commit.getFullMessage(), versionConfig.getKeywords().getPatchKey())) {
 					versionStrategy.increment(VersionComponentType.PATCH, hash);
 				} else {
 					versionStrategy.increment(VersionComponentType.COMMIT, hash);
@@ -53,9 +53,9 @@ public class JGitVersioner implements Versioner {
 	}
 
 	boolean hasValue(String commitMessage, String keyword) {
-		if(versionConfig.getKeywords().isUseRegex()){
+		if (versionConfig.getKeywords().isUseRegex()) {
 			return commitMessage.matches(keyword);
-		}else {
+		} else {
 			return commitMessage.contains(keyword);
 		}
 	}

--- a/git-versioner-maven-core/src/main/java/com/github/manikmagar/maven/versioner/core/git/JGitVersioner.java
+++ b/git-versioner-maven-core/src/main/java/com/github/manikmagar/maven/versioner/core/git/JGitVersioner.java
@@ -6,6 +6,7 @@ import com.github.manikmagar.maven.versioner.core.version.*;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.revwalk.RevCommit;
 
+import java.io.File;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -13,14 +14,16 @@ import java.util.stream.StreamSupport;
 
 public class JGitVersioner implements Versioner {
 
+	File basePath;
 	VersionConfig versionConfig;
 
-	public JGitVersioner(VersionConfig versionConfig) {
+	public JGitVersioner(File basePath, VersionConfig versionConfig) {
 		this.versionConfig = versionConfig;
+		this.basePath = basePath;
 	}
 
 	public VersionStrategy version() {
-		return JGit.executeOperation(git -> {
+		return JGit.executeOperation(basePath, git -> {
 			var branch = git.getRepository().getBranch();
 			Ref head = git.getRepository().findRef("HEAD");
 			var hash = "";

--- a/git-versioner-maven-core/src/test/java/com/github/manikmagar/maven/versioner/core/git/JGitVersionerTest.java
+++ b/git-versioner-maven-core/src/test/java/com/github/manikmagar/maven/versioner/core/git/JGitVersionerTest.java
@@ -3,6 +3,7 @@ package com.github.manikmagar.maven.versioner.core.git;
 import com.github.manikmagar.maven.versioner.core.params.VersionConfig;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
+import org.assertj.core.util.Files;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -10,29 +11,27 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(JUnitParamsRunner.class)
 public class JGitVersionerTest {
-    private VersionConfig versionConfig = new VersionConfig();;
-    private JGitVersioner jGitVersioner = new JGitVersioner(versionConfig);
+	private VersionConfig versionConfig = new VersionConfig();
+	private JGitVersioner jGitVersioner = new JGitVersioner(Files.currentFolder(), versionConfig);
 
-    @Test
-    @Parameters(value = {
-            "Fix: [minor] corrected typo, .*\\[minor\\].*, true",
-            "[minor] Fix: corrected typo, ^\\[minor\\].*, true",
-            "Fix: [minor] corrected typo, ^\\[minor\\].*, false",
-            "Update: improved performance, [minor], false"})
-    public void testHasValueWithRegex(String commitMessage, String keyword, boolean expected) {
-        versionConfig.getKeywords().setUseRegex(true);
+	@Test
+	@Parameters(value = {"Fix: [minor] corrected typo, .*\\[minor\\].*, true",
+			"[minor] Fix: corrected typo, ^\\[minor\\].*, true", "Fix: [minor] corrected typo, ^\\[minor\\].*, false",
+			"Update: improved performance, [minor], false"})
+	public void testHasValueWithRegex(String commitMessage, String keyword, boolean expected) {
+		versionConfig.getKeywords().setUseRegex(true);
 
-        assertThat(jGitVersioner.hasValue(commitMessage, keyword)).isEqualTo(expected);
-    }
+		assertThat(jGitVersioner.hasValue(commitMessage, keyword)).isEqualTo(expected);
+	}
 
-    @Test
-    public void testHasValueWithoutRegex() {
-        versionConfig.getKeywords().setUseRegex(false);
+	@Test
+	public void testHasValueWithoutRegex() {
+		versionConfig.getKeywords().setUseRegex(false);
 
-        String commitMessage = "Fix: [minor] corrected typo";
-        assertThat(jGitVersioner.hasValue(commitMessage, "[minor]")).isTrue();
+		String commitMessage = "Fix: [minor] corrected typo";
+		assertThat(jGitVersioner.hasValue(commitMessage, "[minor]")).isTrue();
 
-        commitMessage = "Update: improved performance";
-        assertThat(jGitVersioner.hasValue(commitMessage, "[minor]")).isFalse();
-    }
+		commitMessage = "Update: improved performance";
+		assertThat(jGitVersioner.hasValue(commitMessage, "[minor]")).isFalse();
+	}
 }

--- a/git-versioner-maven-core/src/test/java/com/github/manikmagar/maven/versioner/plugin/mojo/params/VersionConfigTest.java
+++ b/git-versioner-maven-core/src/test/java/com/github/manikmagar/maven/versioner/plugin/mojo/params/VersionConfigTest.java
@@ -36,8 +36,8 @@ public class VersionConfigTest {
 		VersionKeywords versionKeywords = new VersionKeywords();
 		versionKeywords.setMajorKey("[TEST]");
 		versionConfig.setKeywords(versionKeywords);
-		assertThat(versionConfig.getKeywords()).extracting("majorKey", "minorKey", "patchKey", "useRegex").containsExactly("[TEST]",
-				KEY_MINOR, KEY_PATCH, false);
+		assertThat(versionConfig.getKeywords()).extracting("majorKey", "minorKey", "patchKey", "useRegex")
+				.containsExactly("[TEST]", KEY_MINOR, KEY_PATCH, false);
 	}
 
 	@Test
@@ -46,7 +46,7 @@ public class VersionConfigTest {
 		VersionKeywords versionKeywords = new VersionKeywords();
 		versionKeywords.setUseRegex(true);
 		versionConfig.setKeywords(versionKeywords);
-		assertThat(versionConfig.getKeywords()).extracting("majorKey", "minorKey", "patchKey", "useRegex").containsExactly(KEY_MAJOR,
-				KEY_MINOR, KEY_PATCH, true);
+		assertThat(versionConfig.getKeywords()).extracting("majorKey", "minorKey", "patchKey", "useRegex")
+				.containsExactly(KEY_MAJOR, KEY_MINOR, KEY_PATCH, true);
 	}
 }

--- a/git-versioner-maven-core/src/test/java/com/github/manikmagar/maven/versioner/plugin/mojo/params/VersionKeywordsTest.java
+++ b/git-versioner-maven-core/src/test/java/com/github/manikmagar/maven/versioner/plugin/mojo/params/VersionKeywordsTest.java
@@ -15,8 +15,8 @@ public class VersionKeywordsTest {
 
 	@Test
 	public void defaultKeywords() {
-		assertThat(new VersionKeywords()).extracting("majorKey", "minorKey", "patchKey","useRegex").containsExactly(KEY_MAJOR,
-				KEY_MINOR, KEY_PATCH, false);
+		assertThat(new VersionKeywords()).extracting("majorKey", "minorKey", "patchKey", "useRegex")
+				.containsExactly(KEY_MAJOR, KEY_MINOR, KEY_PATCH, false);
 	}
 
 	@Test

--- a/git-versioner-maven-extension/pom.xml
+++ b/git-versioner-maven-extension/pom.xml
@@ -32,6 +32,10 @@
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-verifier</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/git-versioner-maven-extension/src/main/java/com/github/manikmagar/maven/versioner/extension/GitVersionerModelProcessor.java
+++ b/git-versioner-maven-extension/src/main/java/com/github/manikmagar/maven/versioner/extension/GitVersionerModelProcessor.java
@@ -187,8 +187,7 @@ public class GitVersionerModelProcessor extends DefaultModelProcessor {
 		String config = String.format(
 				"<configuration>	<versionConfig>		<keywords>			<majorKey>%s</majorKey>"
 						+ "			<minorKey>%s</minorKey>			<patchKey>%s</patchKey>"
-						+ "			<useRegex>%s</useRegex>"
-						+ "		</keywords>	</versionConfig></configuration>",
+						+ "			<useRegex>%s</useRegex>" + "		</keywords>	</versionConfig></configuration>",
 				versionConfig.getKeywords().getMajorKey(), versionConfig.getKeywords().getMinorKey(),
 				versionConfig.getKeywords().getPatchKey(), versionConfig.getKeywords().isUseRegex());
 		try {
@@ -212,7 +211,7 @@ public class GitVersionerModelProcessor extends DefaultModelProcessor {
 		keywords.setMajorKey(properties.getProperty(VersionKeywords.GV_KEYWORDS_MAJOR_KEY));
 		keywords.setMinorKey(properties.getProperty(VersionKeywords.GV_KEYWORDS_MINOR_KEY));
 		keywords.setPatchKey(properties.getProperty(VersionKeywords.GV_KEYWORDS_PATCH_KEY));
-		keywords.setUseRegex(properties.getProperty(VersionKeywords.GV_KEYWORDS_KEY_USEREGEX,"false").equals("true"));
+		keywords.setUseRegex(properties.getProperty(VersionKeywords.GV_KEYWORDS_KEY_USEREGEX, "false").equals("true"));
 		coreVersionConfig.setKeywords(keywords);
 
 		VersionPattern versionPattern = new VersionPattern();

--- a/git-versioner-maven-extension/src/main/java/com/github/manikmagar/maven/versioner/extension/GitVersionerModelProcessor.java
+++ b/git-versioner-maven-extension/src/main/java/com/github/manikmagar/maven/versioner/extension/GitVersionerModelProcessor.java
@@ -87,7 +87,7 @@ public class GitVersionerModelProcessor extends DefaultModelProcessor {
 			LOGGER.info(MessageUtils.buffer().a("--- ").mojo(extensionGAV).a(" ").strong("[core-extension]").a(" ---")
 					.toString());
 			versionConfig = loadConfig();
-			versionStrategy = new JGitVersioner(versionConfig).version();
+			versionStrategy = new JGitVersioner(projectModel.getPomFile().getAbsoluteFile(), versionConfig).version();
 			findRelatedProjects(projectModel);
 			initialized = true;
 		}

--- a/git-versioner-maven-plugin/src/main/java/com/github/manikmagar/maven/versioner/plugin/mojo/AbstractVersionerMojo.java
+++ b/git-versioner-maven-plugin/src/main/java/com/github/manikmagar/maven/versioner/plugin/mojo/AbstractVersionerMojo.java
@@ -40,7 +40,7 @@ public abstract class AbstractVersionerMojo extends AbstractMojo {
 	}
 
 	protected Versioner getVersioner() {
-		return new JGitVersioner(getVersionConfig().toVersionConfig());
+		return new JGitVersioner(mavenProject.getBasedir().getAbsoluteFile(), getVersionConfig().toVersionConfig());
 	}
 
 	protected String replaceTokens(String pattern, VersionStrategy versionStrategy) {

--- a/git-versioner-maven-plugin/src/main/java/com/github/manikmagar/maven/versioner/plugin/mojo/Tag.java
+++ b/git-versioner-maven-plugin/src/main/java/com/github/manikmagar/maven/versioner/plugin/mojo/Tag.java
@@ -58,12 +58,12 @@ public class Tag extends AbstractVersionerMojo {
 		var tagMessage = replaceTokens(getTagMessagePattern(), versionStrategy);
 		getLog().info("Current Version: " + versionStrategy.toVersionString());
 		getLog().info(String.format("Tag Version '%s' with message '%s'", tagName, tagMessage));
-		if (GitTag.exists(tagName)) {
+		if (GitTag.exists(mavenProject.getBasedir().getAbsoluteFile(), tagName)) {
 			getLog().error(String.format("Tag already exist: %s", tagName));
 			if (isFailWhenTagExist())
 				throw new GitVersionerException("Tag already exist: " + tagName);
 		} else {
-			String tagId = GitTag.create(tagName, tagMessage);
+			String tagId = GitTag.create(mavenProject.getBasedir().getAbsoluteFile(), tagName, tagMessage);
 			getLog().info(String.format("Created tag: '%s'", tagId));
 		}
 	}

--- a/git-versioner-maven-plugin/src/test/java/com/github/manikmagar/maven/versioner/plugin/mojo/AbstractVersionerMojoTest.java
+++ b/git-versioner-maven-plugin/src/test/java/com/github/manikmagar/maven/versioner/plugin/mojo/AbstractVersionerMojoTest.java
@@ -7,10 +7,10 @@ import com.github.manikmagar.maven.versioner.plugin.mojo.params.InitialVersionPa
 import com.github.manikmagar.maven.versioner.plugin.mojo.params.VersionConfigParam;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
 import org.junit.Test;
 
-import com.github.manikmagar.maven.versioner.core.params.InitialVersion;
-import com.github.manikmagar.maven.versioner.core.params.VersionConfig;
+import java.io.File;
 
 import static com.github.manikmagar.maven.versioner.core.params.VersionKeywords.*;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -18,6 +18,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class AbstractVersionerMojoTest {
 
 	private AbstractVersionerMojo testMojo = new AbstractVersionerMojo() {
+
+		{
+			mavenProject = new MavenProject();
+			mavenProject.setFile(new File("my/pom.xml"));
+		}
 		@Override
 		public void execute() throws MojoExecutionException, MojoFailureException {
 

--- a/git-versioner-maven-plugin/src/test/java/com/github/manikmagar/maven/versioner/plugin/mojo/params/VersionKeywordsParamTest.java
+++ b/git-versioner-maven-plugin/src/test/java/com/github/manikmagar/maven/versioner/plugin/mojo/params/VersionKeywordsParamTest.java
@@ -9,8 +9,8 @@ public class VersionKeywordsParamTest {
 
 	@Test
 	public void newVersionKeywords() {
-		assertThat(new VersionKeywords("[big]", "[medium]", "[small]", false)).extracting("majorKey", "minorKey", "patchKey")
-				.containsExactly("[big]", "[medium]", "[small]");
+		assertThat(new VersionKeywords("[big]", "[medium]", "[small]", false))
+				.extracting("majorKey", "minorKey", "patchKey").containsExactly("[big]", "[medium]", "[small]");
 	}
 
 	@Test


### PR DESCRIPTION
This PR should fix issue #24 in most cases by always passing the base dir of the maven project.

One area that is not covered is when using multiple worktrees, which could be considered as an edge case and an acceptable trade-off.