### PR TITLE
Add possibility to use regex in commit message check

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -31,7 +31,7 @@ values such as Git hash, branch name etc.
 
 See https://github.com/manikmagar/git-versioner-maven-extension-examples[manikmagar/git-versioner-maven-extension-examples]
  for examples of using this extension.
- 
+
 [#versionKeywords]
 == What are version keywords?
 *Version keywords* are the reserved words that describes which milestone of the release is this.
@@ -202,6 +202,20 @@ gv.keywords.minorKey=[SMALL]
 gv.keywords.patchKey=[FIX]
 ----
 
+=== Use regex for version keywords
+You can also use regex to match version keywords.
+This is useful when you want to be sure that the version keyword will only be matched when it is the first word in the commit message.
+So if for example you have a merge commit message which contains the messages of the merged commits, you can use a regex to match only the first commit message.
+
+To use regex for version keywords, you can add following properties to `.mvn/git-versioner.extensions.properties` file -
+
+.Example configuration for regex version keywords
+----
+gv.keywords.useRegex=true
+gv.keywords.majorKey=^\\[major\\].*
+gv.keywords.minorKey=^\\[minor\\].*
+gv.keywords.patchKey=^\\[patch\\].*
+----
 
 == How to access generated version properties?
 This extension adds all version properties to *Maven properties* during build cycle -

--- a/git-versioner-maven-core/src/main/java/com/github/manikmagar/maven/versioner/core/git/JGitVersioner.java
+++ b/git-versioner-maven-core/src/main/java/com/github/manikmagar/maven/versioner/core/git/JGitVersioner.java
@@ -35,11 +35,11 @@ public class JGitVersioner implements Versioner {
 					.collect(Collectors.toList());
 			Collections.reverse(revCommits);
 			for (RevCommit commit : revCommits) {
-				if (commit.getFullMessage().contains(versionConfig.getKeywords().getMajorKey())) {
+				if (hasValue(commit.getFullMessage(), versionConfig.getKeywords().getMajorKey())) {
 					versionStrategy.increment(VersionComponentType.MAJOR, hash);
-				} else if (commit.getFullMessage().contains(versionConfig.getKeywords().getMinorKey())) {
+				} else if (hasValue(commit.getFullMessage(), versionConfig.getKeywords().getMinorKey())) {
 					versionStrategy.increment(VersionComponentType.MINOR, hash);
-				} else if (commit.getFullMessage().contains(versionConfig.getKeywords().getPatchKey())) {
+				} else if (hasValue(commit.getFullMessage(),versionConfig.getKeywords().getPatchKey())) {
 					versionStrategy.increment(VersionComponentType.PATCH, hash);
 				} else {
 					versionStrategy.increment(VersionComponentType.COMMIT, hash);
@@ -47,5 +47,13 @@ public class JGitVersioner implements Versioner {
 			}
 			return versionStrategy;
 		});
+	}
+
+	boolean hasValue(String commitMessage, String keyword) {
+		if(versionConfig.getKeywords().isUseRegex()){
+			return commitMessage.matches(keyword);
+		}else {
+			return commitMessage.contains(keyword);
+		}
 	}
 }

--- a/git-versioner-maven-core/src/main/java/com/github/manikmagar/maven/versioner/core/params/VersionKeywords.java
+++ b/git-versioner-maven-core/src/main/java/com/github/manikmagar/maven/versioner/core/params/VersionKeywords.java
@@ -13,6 +13,7 @@ public final class VersionKeywords {
 	public static final String GV_KEYWORDS_MAJOR_KEY = "gv.keywords.majorKey";
 	public static final String GV_KEYWORDS_MINOR_KEY = "gv.keywords.minorKey";
 	public static final String GV_KEYWORDS_PATCH_KEY = "gv.keywords.patchKey";
+	public static final String GV_KEYWORDS_KEY_USEREGEX = "gv.keywords.useRegex";
 
 	/**
 	 * The keyword for calculating major version of the SemVer.
@@ -26,11 +27,16 @@ public final class VersionKeywords {
 	 * The keyword for calculating patch version of the SemVer.
 	 */
 	private String patchKey = KEY_PATCH;
+	/**
+	 * Whether to use regex for matching keywords.
+	 */
+	private boolean useRegex = false;
 
-	public VersionKeywords(String majorKey, String minorKey, String patchKey) {
+	public VersionKeywords(String majorKey, String minorKey, String patchKey, boolean useRegex) {
 		setMajorKey(majorKey);
 		setMinorKey(minorKey);
 		setPatchKey(patchKey);
+		setUseRegex(useRegex);
 	}
 	public VersionKeywords() {
 
@@ -70,6 +76,14 @@ public final class VersionKeywords {
 		} else {
 			this.patchKey = patchKey;
 		}
+	}
+
+	public void setUseRegex(boolean useRegex) {
+		this.useRegex = useRegex;
+	}
+
+	public boolean isUseRegex() {
+		return useRegex;
 	}
 
 	@Override

--- a/git-versioner-maven-core/src/test/java/com/github/manikmagar/maven/versioner/core/git/JGitVersionerTest.java
+++ b/git-versioner-maven-core/src/test/java/com/github/manikmagar/maven/versioner/core/git/JGitVersionerTest.java
@@ -1,0 +1,38 @@
+package com.github.manikmagar.maven.versioner.core.git;
+
+import com.github.manikmagar.maven.versioner.core.params.VersionConfig;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(JUnitParamsRunner.class)
+public class JGitVersionerTest {
+    private VersionConfig versionConfig = new VersionConfig();;
+    private JGitVersioner jGitVersioner = new JGitVersioner(versionConfig);
+
+    @Test
+    @Parameters(value = {
+            "Fix: [minor] corrected typo, .*\\[minor\\].*, true",
+            "[minor] Fix: corrected typo, ^\\[minor\\].*, true",
+            "Fix: [minor] corrected typo, ^\\[minor\\].*, false",
+            "Update: improved performance, [minor], false"})
+    public void testHasValueWithRegex(String commitMessage, String keyword, boolean expected) {
+        versionConfig.getKeywords().setUseRegex(true);
+
+        assertThat(jGitVersioner.hasValue(commitMessage, keyword)).isEqualTo(expected);
+    }
+
+    @Test
+    public void testHasValueWithoutRegex() {
+        versionConfig.getKeywords().setUseRegex(false);
+
+        String commitMessage = "Fix: [minor] corrected typo";
+        assertThat(jGitVersioner.hasValue(commitMessage, "[minor]")).isTrue();
+
+        commitMessage = "Update: improved performance";
+        assertThat(jGitVersioner.hasValue(commitMessage, "[minor]")).isFalse();
+    }
+}

--- a/git-versioner-maven-core/src/test/java/com/github/manikmagar/maven/versioner/plugin/mojo/params/VersionConfigTest.java
+++ b/git-versioner-maven-core/src/test/java/com/github/manikmagar/maven/versioner/plugin/mojo/params/VersionConfigTest.java
@@ -36,7 +36,17 @@ public class VersionConfigTest {
 		VersionKeywords versionKeywords = new VersionKeywords();
 		versionKeywords.setMajorKey("[TEST]");
 		versionConfig.setKeywords(versionKeywords);
-		assertThat(versionConfig.getKeywords()).extracting("majorKey", "minorKey", "patchKey").containsExactly("[TEST]",
-				KEY_MINOR, KEY_PATCH);
+		assertThat(versionConfig.getKeywords()).extracting("majorKey", "minorKey", "patchKey", "useRegex").containsExactly("[TEST]",
+				KEY_MINOR, KEY_PATCH, false);
+	}
+
+	@Test
+	public void setUseRegEx() {
+		VersionConfig versionConfig = new VersionConfig();
+		VersionKeywords versionKeywords = new VersionKeywords();
+		versionKeywords.setUseRegex(true);
+		versionConfig.setKeywords(versionKeywords);
+		assertThat(versionConfig.getKeywords()).extracting("majorKey", "minorKey", "patchKey", "useRegex").containsExactly(KEY_MAJOR,
+				KEY_MINOR, KEY_PATCH, true);
 	}
 }

--- a/git-versioner-maven-core/src/test/java/com/github/manikmagar/maven/versioner/plugin/mojo/params/VersionKeywordsTest.java
+++ b/git-versioner-maven-core/src/test/java/com/github/manikmagar/maven/versioner/plugin/mojo/params/VersionKeywordsTest.java
@@ -15,8 +15,8 @@ public class VersionKeywordsTest {
 
 	@Test
 	public void defaultKeywords() {
-		assertThat(new VersionKeywords()).extracting("majorKey", "minorKey", "patchKey").containsExactly(KEY_MAJOR,
-				KEY_MINOR, KEY_PATCH);
+		assertThat(new VersionKeywords()).extracting("majorKey", "minorKey", "patchKey","useRegex").containsExactly(KEY_MAJOR,
+				KEY_MINOR, KEY_PATCH, false);
 	}
 
 	@Test
@@ -43,4 +43,11 @@ public class VersionKeywordsTest {
 		assertThat(versionKeywords.getPatchKey()).as(keyType).isEqualTo(expected);
 	}
 
+	@Test
+	@Parameters(value = {"true", "false"})
+	public void setUseRegex(boolean useRegex) {
+		var versionKeywords = new VersionKeywords();
+		versionKeywords.setUseRegex(useRegex);
+		assertThat(versionKeywords.isUseRegex()).isEqualTo(useRegex);
+	}
 }

--- a/git-versioner-maven-extension/src/main/java/com/github/manikmagar/maven/versioner/extension/GitVersionerModelProcessor.java
+++ b/git-versioner-maven-extension/src/main/java/com/github/manikmagar/maven/versioner/extension/GitVersionerModelProcessor.java
@@ -187,9 +187,10 @@ public class GitVersionerModelProcessor extends DefaultModelProcessor {
 		String config = String.format(
 				"<configuration>	<versionConfig>		<keywords>			<majorKey>%s</majorKey>"
 						+ "			<minorKey>%s</minorKey>			<patchKey>%s</patchKey>"
+						+ "			<useRegex>%s</useRegex>"
 						+ "		</keywords>	</versionConfig></configuration>",
 				versionConfig.getKeywords().getMajorKey(), versionConfig.getKeywords().getMinorKey(),
-				versionConfig.getKeywords().getPatchKey());
+				versionConfig.getKeywords().getPatchKey(), versionConfig.getKeywords().isUseRegex());
 		try {
 			Xpp3Dom configDom = Xpp3DomBuilder.build(new StringReader(config));
 			plugin.setConfiguration(configDom);
@@ -211,6 +212,7 @@ public class GitVersionerModelProcessor extends DefaultModelProcessor {
 		keywords.setMajorKey(properties.getProperty(VersionKeywords.GV_KEYWORDS_MAJOR_KEY));
 		keywords.setMinorKey(properties.getProperty(VersionKeywords.GV_KEYWORDS_MINOR_KEY));
 		keywords.setPatchKey(properties.getProperty(VersionKeywords.GV_KEYWORDS_PATCH_KEY));
+		keywords.setUseRegex(properties.getProperty(VersionKeywords.GV_KEYWORDS_KEY_USEREGEX,"false").equals("true"));
 		coreVersionConfig.setKeywords(keywords);
 
 		VersionPattern versionPattern = new VersionPattern();

--- a/git-versioner-maven-plugin/src/main/java/com/github/manikmagar/maven/versioner/plugin/mojo/params/VersionKeywordsParam.java
+++ b/git-versioner-maven-plugin/src/main/java/com/github/manikmagar/maven/versioner/plugin/mojo/params/VersionKeywordsParam.java
@@ -29,10 +29,14 @@ public final class VersionKeywordsParam {
 	@Parameter(name = "patchKey", defaultValue = KEY_PATCH, property = GV_KEYWORDS_PATCH_KEY)
 	private String patchKey = KEY_PATCH;
 
-	public VersionKeywordsParam(String majorKey, String minorKey, String patchKey) {
+	@Parameter(name = "useRegex", defaultValue = "false", property = GV_KEYWORDS_KEY_USEREGEX)
+	private boolean useRegex = false;
+
+	public VersionKeywordsParam(String majorKey, String minorKey, String patchKey, boolean useRegex) {
 		this.majorKey = majorKey;
 		this.minorKey = minorKey;
 		this.patchKey = patchKey;
+		this.useRegex = useRegex;
 	}
 
 	public VersionKeywordsParam() {
@@ -51,8 +55,12 @@ public final class VersionKeywordsParam {
 		return patchKey;
 	}
 
+	public boolean isUseRegex() {
+		return useRegex;
+	}
+
 	public VersionKeywords toVersionKeywords() {
-		return new VersionKeywords(getMajorKey(), getMinorKey(), getPatchKey());
+		return new VersionKeywords(getMajorKey(), getMinorKey(), getPatchKey(), isUseRegex());
 	}
 	@Override
 	public boolean equals(Object o) {
@@ -62,7 +70,7 @@ public final class VersionKeywordsParam {
 			return false;
 		VersionKeywordsParam that = (VersionKeywordsParam) o;
 		return getMajorKey().equals(that.getMajorKey()) && getMinorKey().equals(that.getMinorKey())
-				&& getPatchKey().equals(that.getPatchKey());
+				&& getPatchKey().equals(that.getPatchKey()) && isUseRegex() == that.isUseRegex();
 	}
 
 	@Override

--- a/git-versioner-maven-plugin/src/test/java/com/github/manikmagar/maven/versioner/plugin/mojo/params/VersionKeywordsParamTest.java
+++ b/git-versioner-maven-plugin/src/test/java/com/github/manikmagar/maven/versioner/plugin/mojo/params/VersionKeywordsParamTest.java
@@ -9,7 +9,7 @@ public class VersionKeywordsParamTest {
 
 	@Test
 	public void newVersionKeywords() {
-		assertThat(new VersionKeywords("[big]", "[medium]", "[small]")).extracting("majorKey", "minorKey", "patchKey")
+		assertThat(new VersionKeywords("[big]", "[medium]", "[small]", false)).extracting("majorKey", "minorKey", "patchKey")
 				.containsExactly("[big]", "[medium]", "[small]");
 	}
 
@@ -20,8 +20,8 @@ public class VersionKeywordsParamTest {
 	}
 	@Test
 	public void toCustomVersionKeywords() {
-		assertThat(new VersionKeywordsParam("[big]", "[medium]", "[small]"))
+		assertThat(new VersionKeywordsParam("[big]", "[medium]", "[small]", false))
 				.extracting(VersionKeywordsParam::toVersionKeywords)
-				.isEqualTo(new VersionKeywords("[big]", "[medium]", "[small]"));
+				.isEqualTo(new VersionKeywords("[big]", "[medium]", "[small]", false));
 	}
 }


### PR DESCRIPTION
I want to make sure that only commit messages that start with a keyword are considered while incrementing versions. Otherwise it might be that they are also considered when doing merge commits for example.