### PR TITLE
fix: jabel configuration for Java 8 support

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -1,8 +1,27 @@
 = Contributing
-
+ifndef::env-github[:icons: font]
+ifdef::env-github[]
+:caution-caption: :fire:
+:important-caption: :exclamation:
+:note-caption: :paperclip:
+:tip-caption: :bulb:
+:warning-caption: :warning:
+endif::[]
 
 == Build
 
+=== Java Support
+
+Source code uses *Java 11* for development, however the API compatibility is restricted to *Java 8*.
+This allows us to use the syntactical sugar advancements such as var, switch etc but still _support Java 8 projects_.
+This is achieved with the use of https://github.com/bsideup/jabel[Jabel - javac compiler plugin].
+
+- Development dependency: Java 11
+- Runtime dependency: Java 8+
+
+WARNING: Using Java 9+ APIs will result in compilation failure. See https://github.com/bsideup/jabel#how-jabel-works[how and why Jabel works] for more details.
+
+=== Installation
 Install artifacts to local repository -
 
 [source,shell]
@@ -11,7 +30,7 @@ Install artifacts to local repository -
 ----
 
 == Releasing
-Github Actions workflow is configured to use this same extension to version the project
+GitHub Actions workflow is configured to use this same extension to version the project
 and then use https://jreleaser.org/[JReleaser] to release this to https://search.maven.org/search?q=a:git-versioner-maven-extension[Maven Central].
 
 _To trigger the release:_

--- a/README.adoc
+++ b/README.adoc
@@ -278,5 +278,9 @@ For Tag goal, it is possible to configure pom.xml to contain the git-versioner p
 <2> Tag name pattern to use. Default `v%v` will result in tags like `v1.2.3`.
 <3> Tag message pattern to use. Default `Release version %v` will add tag message like `Release version 1.2.3`.
 
+== Contributing
+
+All contributions are welcome. Please see link:CONTRIBUTING.adoc[Contributing] guides.
+
 == Acknowledgement
 This is inspired from Gradle plugin https://github.com/toolebox-io/gradle-git-versioner[toolebox-io/gradle-git-versioner] that I have been using for my Gradle projects. This maven plugin is my attempt to get those auto-version capabilities into my Maven builds.

--- a/git-versioner-maven-core/src/main/java/com/github/manikmagar/maven/versioner/core/version/VersionPatternStrategy.java
+++ b/git-versioner-maven-core/src/main/java/com/github/manikmagar/maven/versioner/core/version/VersionPatternStrategy.java
@@ -12,7 +12,7 @@ public class VersionPatternStrategy extends SemVerStrategy {
 	public VersionPatternStrategy(int major, int minor, int patch, String branchName, String hashRef,
 			String versionPattern) {
 		super(major, minor, patch, branchName, hashRef);
-		if (versionPattern == null || versionPattern.isBlank()) {
+		if (versionPattern == null || versionPattern.trim().isEmpty()) {
 			this.versionPattern = DEFAULT_VERSION_PATTERN;
 		} else {
 			this.versionPattern = versionPattern;
@@ -69,7 +69,7 @@ public class VersionPatternStrategy extends SemVerStrategy {
 				// Full regex to match the version string containing group regex
 				var fullRegex = ".*" + token.getTokenGroupRegex() + ".*";
 				if (Pattern.matches(fullRegex, text)) {
-					if (value != null && !value.isBlank() && !value.equals("0")) {
+					if (value != null && !value.trim().isEmpty() && !value.equals("0")) {
 						text = text.replace(token.getToken(), value);
 					} else {
 						text = text.replaceAll(token.getTokenGroupRegex(), "");

--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <java.version>17</java.version>
     <maven.version>3.8.1</maven.version>
     <project.github.repository>manikmagar/git-versioner-maven-plugin</project.github.repository>
     <nexus.url>https://oss.sonatype.org</nexus.url>
@@ -204,6 +203,20 @@
         </plugin>
       </plugins>
     </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <release>8</release>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
+          <compilerArgs>
+            <arg>-Xplugin:jabel</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+    </plugins>
   </build>
 
   <dependencyManagement>
@@ -211,7 +224,8 @@
       <dependency>
         <groupId>org.eclipse.jgit</groupId>
         <artifactId>org.eclipse.jgit</artifactId>
-        <version>6.6.1.202309021850-r</version>
+        <!--Using 5.* version to stay compatible with Java 8-->
+        <version>5.13.1.202206130422-r</version>
       </dependency>
       <dependency>
         <groupId>org.twdata.maven</groupId>


### PR DESCRIPTION
- Avoid using Java 9+ APIs
- Use Java 8 compatible dependencies
- Fix the Jabel configuration

Fixes #36 